### PR TITLE
Load Import CSV from Query Parameter

### DIFF
--- a/OpenBudgeteer.Blazor/Pages/Import.razor
+++ b/OpenBudgeteer.Blazor/Pages/Import.razor
@@ -6,9 +6,14 @@
 @using OpenBudgeteer.Core.Common
 @using OpenBudgeteer.Core.Models
 @using Tewr.Blazor.FileReader
+@using Microsoft.AspNetCore.WebUtilities
+@using Microsoft.AspNetCore.Components
+@using System.IO
+@using System.Text
 @inject DbContextOptions<DatabaseContext> DbContextOptions
 @inject IFileReaderService FileReaderService
 @inject IJSRuntime JSRuntime
+@inject NavigationManager NavManager
 
 <div class="accordion" id="accordionSteps">
     <div class="accordion-item">
@@ -261,7 +266,7 @@
     </div>
     <div class="accordion-item">
         <h2 class="accordion-header" id="headingStepFour">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseStepFour" aria-expanded="false" aria-controls="collapseStepFour" disabled="@(!_step4Enabled)">
+            <button @ref="_step4AccordionButtonElement" class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseStepFour" aria-expanded="false" aria-controls="collapseStepFour" disabled="@(!_step4Enabled)">
                 @if (_step4Enabled)
                 {
                     <div>Step 4: Validate and Import Data</div>
@@ -466,6 +471,7 @@
 
     ElementReference _inputElement;
     ElementReference _step1AccordionButtonElement;
+    ElementReference _step4AccordionButtonElement;
 
     readonly Guid PlaceholderItemId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     readonly string PlaceholderItemValue = "___PlaceholderItem___";
@@ -488,6 +494,7 @@
     bool _step3Enabled;
     bool _step4Enabled;
     bool _forceShowStep1;
+    bool _forceShowStep4;
 
     bool _isValidationRunning;
     bool _isImportRunning;
@@ -509,6 +516,7 @@
     {
         _dataContext = new ImportDataViewModel(DbContextOptions);
         LoadData();
+        LoadFromQueryParams();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -518,6 +526,11 @@
         {
             _forceShowStep1 = false;
             await JSRuntime.InvokeVoidAsync("ImportPage.triggerClick", _step1AccordionButtonElement);
+        }
+        if (_forceShowStep4)
+        {
+            _forceShowStep4 = false;
+            await JSRuntime.InvokeVoidAsync("ImportPage.triggerClick", _step4AccordionButtonElement);
         }
     }
 
@@ -529,6 +542,54 @@
         _dataContext.SelectedImportProfile = _dummyImportProfile;
         _dataContext.IdentifiedColumns.Insert(0, DummyColumn);
         _dataContext.SelectedAccount = _dummyAccount;
+    }
+
+    async void LoadFromQueryParams()
+    {
+        var uri = NavManager.ToAbsoluteUri(NavManager.Uri);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+
+        if (query.TryGetValue("csv", out var csv64))
+        {
+            HandleResult(await LoadCSVFromBase64String(csv64));
+        }
+
+        if (_step2Enabled && query.TryGetValue("profile", out var profileName))
+        {
+            var profile = _dataContext.AvailableImportProfiles.FirstOrDefault(i => i.ProfileName == profileName, _dummyImportProfile);
+            _dataContext.SelectedImportProfile = profile;
+            ImportProfile_SelectionChanged();
+        }
+
+        if (_step4Enabled)
+        {
+            await ValidateDataAsync();
+            _forceShowStep4 = true;
+            StateHasChanged();
+        }
+    }
+
+    public async Task<ViewModelOperationResult> LoadCSVFromBase64String(String csv64)
+    {
+        try
+        {
+            var csv = Encoding.UTF8.GetString(Convert.FromBase64String(csv64));
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+            writer.Write(csv);
+            writer.Flush();
+            stream.Position = 0;
+            var res = await _dataContext.HandleOpenFileAsync(stream);
+            if (res.IsSuccessful)
+            {
+                _step2Enabled = true;
+            }
+            return res;
+        }
+        catch (Exception e)
+        {
+             return new ViewModelOperationResult(false, $"Failed to load CSV: {e.Message}");
+        }
     }
 
     async Task ReadFileAsync()


### PR DESCRIPTION
Instead of a full api, this PR allows to import CSV files via query parameters on the normal Import page.

By specifying
- csv: to a base64 encoded string containing the csv file
- profile: the name of the profile to use for import

the import page opens with all transactions loaded in the preview window. Now, the user can verify the transaction (e.g. check for duplicates) and import them with a single click on "Import Data".

I am now able to quickly import transactions by opening OpenBudgeteer after my bank csv download script:
```
firefox http://localhost:5000/import\?profile\=bank\&csv\=$(base64 -w0 transactions.csv)
```