### PR TITLE
Correctly detect potential duplicates if payee or memo is equal

### DIFF
--- a/OpenBudgeteer.Core/ViewModels/ImportDataViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/ImportDataViewModel.cs
@@ -153,7 +153,7 @@ public class ImportDataViewModel : ViewModelBase
 
         public int GetHashCode(BankTransaction obj)
         {
-            return new { obj.TransactionDate.Date, obj.Amount, obj.Payee, obj.Memo }.GetHashCode();
+            return new { obj.TransactionDate.Date, obj.Amount }.GetHashCode();
         }
     }
 


### PR DESCRIPTION
Fixes `GetHashCode` to work with the `Equals` function to detect potential duplicates if payee OR memo is equal.


> Two objects that are equal return hash codes that are equal. However, the reverse is not true: equal hash codes do not imply object equality, because different (unequal) objects can have identical hash codes.

https://learn.microsoft.com/en-us/dotnet/api/system.object.gethashcode?view=net-7.0#remarks

Now two transactions return the same hashcode and the `Equals` function is used to determine whether they are potential duplicates.