### PR TITLE
Fix navbar in portrait mode

### DIFF
--- a/OpenBudgeteer.Blazor/Shared/NavMenu.razor
+++ b/OpenBudgeteer.Blazor/Shared/NavMenu.razor
@@ -2,7 +2,7 @@
 @using OpenBudgeteer.Data
 @inject DbContextOptions<DatabaseContext> DbContextOptions
 
-<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+<nav class="navbar navbar-expand-sm navbar-dark sticky-top bg-dark">
     <div class="row" style="width: 1500px; margin: auto">
         <div class="col-md-auto">
             <a class="navbar-brand" href="#">OpenBudgeteer</a>

--- a/OpenBudgeteer.Blazor/wwwroot/css/site.css
+++ b/OpenBudgeteer.Blazor/wwwroot/css/site.css
@@ -9,7 +9,7 @@ app {
 }
 
 .content {
-    padding-top: 100px;
+    padding-top: 40px;
 }
 
 .navbar-toggler {


### PR DESCRIPTION
The expanded navbar should not hide the content beneath.

The navbar is now part of the normal content and scrolls with it.

Before: 
![image](https://github.com/TheAxelander/OpenBudgeteer/assets/15067830/16eb06bb-6bd4-438d-a2a5-8c5284000813)


After:
![image](https://github.com/TheAxelander/OpenBudgeteer/assets/15067830/f8054931-0e96-4820-b59f-ff2a1744859e)
