### PR TITLE
Fix Mapping Rules with Account Name

### DIFF
--- a/OpenBudgeteer.Core/ViewModels/ItemViewModels/TransactionViewModelItem.cs
+++ b/OpenBudgeteer.Core/ViewModels/ItemViewModels/TransactionViewModelItem.cs
@@ -579,7 +579,7 @@ public class TransactionViewModelItem : ViewModelBase
         {
             return (comparisionField switch
             {
-                1 => Transaction.AccountId.ToString(),
+                1 => SelectedAccount?.Name ?? "",
                 2 => Transaction.Payee,
                 3 => Transaction.Memo,
                 4 => Transaction.Amount.ToString(CultureInfo.CurrentCulture),


### PR DESCRIPTION
Allows to create mapping rules based on the account name of the transaction