### PR TITLE
Fix adding a mapping rule to an existing RuleSet

### DIFF
--- a/OpenBudgeteer.Core/ViewModels/ItemViewModels/RuleSetViewModelItem.cs
+++ b/OpenBudgeteer.Core/ViewModels/ItemViewModels/RuleSetViewModelItem.cs
@@ -168,10 +168,6 @@ public class RuleSetViewModelItem : ViewModelBase
                 // CREATE
                 if (dbContext.CreateBucketRuleSet(RuleSet) == 0)
                     throw new Exception("Rule could not be created in database.");
-                foreach (var mappingRule in MappingRules)
-                {
-                    mappingRule.MappingRule.BucketRuleSetId = RuleSet.BucketRuleSetId;
-                }
             }
             else
             {
@@ -180,15 +176,13 @@ public class RuleSetViewModelItem : ViewModelBase
                     i.BucketRuleSetId == RuleSet.BucketRuleSetId));
 
                 dbContext.UpdateBucketRuleSet(RuleSet);
-                foreach (var mappingRule in MappingRules)
-                {
-                    mappingRule.GenerateRuleOutput();
-                }
             }
 
             foreach (var mappingRuleViewModelItem in MappingRules)
             {
                 mappingRuleViewModelItem.MappingRule.MappingRuleId = Guid.Empty;
+                mappingRuleViewModelItem.MappingRule.BucketRuleSetId = RuleSet.BucketRuleSetId;
+                mappingRuleViewModelItem.GenerateRuleOutput();
             }
             dbContext.CreateMappingRules(MappingRules
                 .Select(i => i.MappingRule)


### PR DESCRIPTION
Adding a new mapping rule to an existing rule set failed due to the missing `BucketRuleSetId` in the new mapping rule.
```
info: 11/2/2023 21:57:07.541 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command)
      Executed DbCommand (0ms) [Parameters=[@p0='5218bcea-c96c-4278-8ab1-153b3bc26ec0', @p1='37f1851c-2100-4350-8785-2f3e736a2fc3', @p2='1', @p3='1', @p4='foo' (Nullable = false) (Size = 3)], CommandType='Text', CommandTimeout='30']
      INSERT INTO "MappingRule" ("MappingRuleId", "BucketRuleSetId", "ComparisionField", "ComparisionType", "ComparisionValue")
      VALUES (@p0, @p1, @p2, @p3, @p4);
fail: 11/2/2023 21:57:07.542 RelationalEventId.CommandError[20102] (Microsoft.EntityFrameworkCore.Database.Command)
      Failed executing DbCommand (0ms) [Parameters=[@p0='a54fa405-376d-4c79-acd4-4851e1d68100', @p1='00000000-0000-0000-0000-000000000000', @p2='2', @p3='1', @p4='asd' (Nullable = false) (Size = 3)], CommandType='Text', CommandTimeout='30']
      INSERT INTO "MappingRule" ("MappingRuleId", "BucketRuleSetId", "ComparisionField", "ComparisionType", "ComparisionValue")
      VALUES (@p0, @p1, @p2, @p3, @p4);
fail: 11/2/2023 21:57:07.542 CoreEventId.SaveChangesFailed[10000] (Microsoft.EntityFrameworkCore.Update)
      An exception occurred in the database while saving changes for context type 'OpenBudgeteer.Data.DatabaseContext'.
      Microsoft.EntityFrameworkCore.DbUpdateException: An error occurred while saving the entity changes. See the inner exception for details.
       ---> Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'FOREIGN KEY constraint failed'.
```