### PR TITLE
Fix - Error message after creating new Bucket [resolves #234]

### DIFF
--- a/OpenBudgeteer.Core/ViewModels/EntityViewModels/BucketViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/EntityViewModels/BucketViewModel.cs
@@ -449,11 +449,14 @@ public class BucketViewModel : BaseEntityViewModel<Bucket>
         #endregion*/
         
         #region Balance, In & Out
-        
-        var figures = ServiceManager.BucketService.GetFigures(BucketId, _currentYearMonth);
-        Balance = figures.Balance ?? 0;
-        In = figures.Input;
-        Activity = figures.Output;
+
+        if (BucketId != default)
+        {
+            var figures = ServiceManager.BucketService.GetFigures(BucketId, _currentYearMonth);
+            Balance = figures.Balance ?? 0;
+            In = figures.Input;
+            Activity = figures.Output;
+        }
         
         #endregion
 


### PR DESCRIPTION
Calling `BucketService.GetFigures` while creating a new bucket fails since no bucket exists to be retrieved. 