### PR TITLE
Fix - Recurring transaction creates multiple new accounts [resolves #255]

### DIFF
--- a/OpenBudgeteer.Core.Data.Services/Generic/GenericRecurringBankTransactionService.cs
+++ b/OpenBudgeteer.Core.Data.Services/Generic/GenericRecurringBankTransactionService.cs
@@ -81,12 +81,12 @@ public class GenericRecurringBankTransactionService : GenericBaseService<Recurri
         if (transactions.Any(i => i.Account?.IsActive == 0))
             throw new EntityUpdateException("Identified Transactions which would be assigned to an inactive Account");
 
-        // Ensure Account is not assigned to prevent double creation of Accounts
+        // Prevent creation of new accounts
         foreach (var transaction in transactions)
         {
-            transaction.Account = new Account();
+            transaction.Account = null!;
         }
-            
+
         _bankTransactionRepository.CreateRange(transactions);
                 
         return transactions;


### PR DESCRIPTION
Hope you don't mind a contribution from a newbie! I'm completely new to contributing to FOSS projects, so please feel free to share any criticism or advice you might have.

I went ahead and investigated #255 and pinpointed the culprit. I'm not sure what the `Account` property is used for here, since the `Transaction` already has an `AccountId` property that contains the ID of the target account. My understanding is that the creation of new accounts is not an intended side-effect in general, so I went ahead and set the property to null for all (recurring) transactions to prevent the creation of a new account for every iteration of the transaction.

Since we don't have tests that cover this adequately, I went ahead and queried and database to confirm:

Account is displayed correctly now
![image](https://github.com/user-attachments/assets/56739aac-4345-4f9e-a8c3-585a90a1ea18)

No additional accounts created
![image](https://github.com/user-attachments/assets/5d2d60f5-628c-431d-aafa-3e66ca14c8f3)

Transactions are linked to the correct account
![image](https://github.com/user-attachments/assets/a6aae013-db3f-43de-bd03-a4c4ac29083d)
![image](https://github.com/user-attachments/assets/52e621df-0b50-41a2-801c-8b724615f128)


