### PR TITLE
Show split transaction amount in bucket detail list

### DIFF
--- a/OpenBudgeteer.API/Program.cs
+++ b/OpenBudgeteer.API/Program.cs
@@ -167,7 +167,7 @@ bucket.MapGet("{id:guid}", (Guid id) => bucketService.Get(id))
     .MapToApiVersion(1,0);
 bucket.MapGet("/withLatestVersion/{id:guid}", (Guid id) => bucketService.GetWithLatestVersion(id))
     .MapToApiVersion(1,0);
-bucket.MapGet("/", () => bucketService.GetAll())
+bucket.MapGet("/", () => bucketService.GetAllWithoutSystemBuckets())
     .MapToApiVersion(1,0);
 bucket.MapGet("/systemBuckets", () => bucketService.GetSystemBuckets())
     .MapToApiVersion(1,0);

--- a/OpenBudgeteer.Blazor/Shared/BucketDetailsDialog.razor
+++ b/OpenBudgeteer.Blazor/Shared/BucketDetailsDialog.razor
@@ -50,13 +50,13 @@
                                                 <td class="d-none d-md-table-cell">@transaction.SelectedAccount.Name</td>
                                                 <td class="d-none d-md-table-cell">@transaction.Payee</td>
                                                 <td>@transaction.Memo</td>
-                                                @if (transaction.Buckets.Count == 0)
+                                                @if (transaction.Buckets.Count <= 1)
                                                 {
                                                     <td style="text-align: right">@transaction.Amount.ToString("C", CultureInfo.CurrentCulture)</td>
                                                 }
                                                 else
                                                 {
-                                                    <td style="text-align: right">@transaction.Buckets.Where(b => b.SelectedBucketId == DataContext.BucketId).Sum(b => b.Amount).ToString("C", CultureInfo.CurrentCulture)</td>
+                                                    <td style="text-align: right">@transaction.Buckets.Where(b => b.SelectedBucketId == DataContext.BucketId).Sum(b => b.Amount).ToString("C", CultureInfo.CurrentCulture)*</td>
                                                 }
                                             </tr>
                                         }

--- a/OpenBudgeteer.Blazor/Shared/BucketDetailsDialog.razor
+++ b/OpenBudgeteer.Blazor/Shared/BucketDetailsDialog.razor
@@ -2,6 +2,7 @@
 @using OpenBudgeteer.Blazor.Common
 @using OpenBudgeteer.Blazor.ViewModels
 @using System.Globalization
+@using OpenBudgeteer.Core.ViewModels.EntityViewModels
 
 @if (IsDialogVisible)
  {
@@ -49,7 +50,14 @@
                                                 <td class="d-none d-md-table-cell">@transaction.SelectedAccount.Name</td>
                                                 <td class="d-none d-md-table-cell">@transaction.Payee</td>
                                                 <td>@transaction.Memo</td>
-                                                <td style="text-align: right">@transaction.Amount.ToString("C", CultureInfo.CurrentCulture)</td>
+                                                @if (transaction.Buckets.Count == 0)
+                                                {
+                                                    <td style="text-align: right">@transaction.Amount.ToString("C", CultureInfo.CurrentCulture)</td>
+                                                }
+                                                else
+                                                {
+                                                    <td style="text-align: right">@transaction.Buckets.Where(b => b.SelectedBucketId == DataContext.BucketId).Sum(b => b.Amount).ToString("C", CultureInfo.CurrentCulture)</td>
+                                                }
                                             </tr>
                                         }
                                     </tbody>

--- a/OpenBudgeteer.Core.Data.Contracts/Services/IBucketService.cs
+++ b/OpenBudgeteer.Core.Data.Contracts/Services/IBucketService.cs
@@ -5,6 +5,7 @@ namespace OpenBudgeteer.Core.Data.Contracts.Services;
 public interface IBucketService : IBaseService<Bucket>
 {
     public Bucket GetWithLatestVersion(Guid id);
+    public IEnumerable<Bucket> GetAllWithSystemBuckets();
     public IEnumerable<Bucket> GetSystemBuckets();
     public IEnumerable<Bucket> GetActiveBuckets(DateTime validFrom);
     //public BucketVersion GetLatestVersion(Guid bucketId);

--- a/OpenBudgeteer.Core.Data.Contracts/Services/IBucketService.cs
+++ b/OpenBudgeteer.Core.Data.Contracts/Services/IBucketService.cs
@@ -5,7 +5,7 @@ namespace OpenBudgeteer.Core.Data.Contracts.Services;
 public interface IBucketService : IBaseService<Bucket>
 {
     public Bucket GetWithLatestVersion(Guid id);
-    public IEnumerable<Bucket> GetAllWithSystemBuckets();
+    public IEnumerable<Bucket> GetAllWithoutSystemBuckets();
     public IEnumerable<Bucket> GetSystemBuckets();
     public IEnumerable<Bucket> GetActiveBuckets(DateTime validFrom);
     //public BucketVersion GetLatestVersion(Guid bucketId);

--- a/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreBucketService.cs
+++ b/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreBucketService.cs
@@ -47,13 +47,13 @@ public class EFCoreBucketService : EFCoreBaseService<Bucket>, IBucketService
         }
     }
 
-    public IEnumerable<Bucket> GetAllWithSystemBuckets()
+    public IEnumerable<Bucket> GetAllWithoutSystemBuckets()
     {
         try
         {
             using var dbContext = new DatabaseContext(_dbContextOptions);
             var baseService = CreateBaseService(dbContext);
-            return baseService.GetAllWithSystemBuckets();
+            return baseService.GetAllWithoutSystemBuckets();
         }
         catch (Exception e)
         {

--- a/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreBucketService.cs
+++ b/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreBucketService.cs
@@ -47,6 +47,21 @@ public class EFCoreBucketService : EFCoreBaseService<Bucket>, IBucketService
         }
     }
 
+    public IEnumerable<Bucket> GetAllWithSystemBuckets()
+    {
+        try
+        {
+            using var dbContext = new DatabaseContext(_dbContextOptions);
+            var baseService = CreateBaseService(dbContext);
+            return baseService.GetAllWithSystemBuckets();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            throw new Exception($"Error on querying database: {e.Message}");
+        }
+    }
+    
     public override IEnumerable<Bucket> GetAll()
     {
         try

--- a/OpenBudgeteer.Core.Data.Services/Generic/GenericBucketService.cs
+++ b/OpenBudgeteer.Core.Data.Services/Generic/GenericBucketService.cs
@@ -37,7 +37,7 @@ public class GenericBucketService : GenericBaseService<Bucket>, IBucketService
         return result;
     }
 
-    public IEnumerable<Bucket> GetAllWithSystemBuckets()
+    public override IEnumerable<Bucket> GetAll()
     {
         return _bucketRepository
             .All()
@@ -45,7 +45,7 @@ public class GenericBucketService : GenericBaseService<Bucket>, IBucketService
             .ToList();
     }
     
-    public override IEnumerable<Bucket> GetAll()
+    public IEnumerable<Bucket> GetAllWithoutSystemBuckets()
     {
         return _bucketRepository
             .All()

--- a/OpenBudgeteer.Core.Data.Services/Generic/GenericBucketService.cs
+++ b/OpenBudgeteer.Core.Data.Services/Generic/GenericBucketService.cs
@@ -37,6 +37,14 @@ public class GenericBucketService : GenericBaseService<Bucket>, IBucketService
         return result;
     }
 
+    public IEnumerable<Bucket> GetAllWithSystemBuckets()
+    {
+        return _bucketRepository
+            .All()
+            .OrderBy(i => i.Name)
+            .ToList();
+    }
+    
     public override IEnumerable<Bucket> GetAll()
     {
         return _bucketRepository

--- a/OpenBudgeteer.Core/ViewModels/Helper/BucketDetailsViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/Helper/BucketDetailsViewModel.cs
@@ -38,7 +38,7 @@ namespace OpenBudgeteer.Core.ViewModels.Helper
         /// <summary>
         /// Current <see cref="Bucket"/> that will be used
         /// </summary>
-        private readonly Guid _bucketId;
+        public readonly Guid BucketId;
 
         /// <summary>
         /// Reused <see cref="TransactionViewModel"/> to display <see cref="BucketMovement"/> data
@@ -57,7 +57,7 @@ namespace OpenBudgeteer.Core.ViewModels.Helper
             Guid bucketId) : base(serviceManager)
         {
             _yearMonthViewModel = yearMonthViewModel;
-            _bucketId = bucketId;
+            BucketId = bucketId;
             BucketMovementsData = new TransactionListingViewModel(serviceManager, _yearMonthViewModel);
         }
 
@@ -69,7 +69,7 @@ namespace OpenBudgeteer.Core.ViewModels.Helper
         /// <returns>Object which contains information and results of this method</returns>
         public async Task<ViewModelOperationResult> LoadBucketMovementsDataAsync(bool withMovements)
         {
-            return await BucketMovementsData.LoadDataAsync(_bucketId, withMovements);
+            return await BucketMovementsData.LoadDataAsync(BucketId, withMovements);
         }
 
         /// <summary>
@@ -187,13 +187,13 @@ namespace OpenBudgeteer.Core.ViewModels.Helper
         {
             // Get all BankTransaction assigned to this Bucket
             var transactions = ServiceManager.BudgetedTransactionService
-                .GetAllFromBucket(_bucketId, startingMonth, DateTime.MaxValue)
+                .GetAllFromBucket(BucketId, startingMonth, DateTime.MaxValue)
                 .Select(i => new BucketActivity(i))
                 .ToList();
 
             // Append Bucket Movements
             transactions.AddRange(ServiceManager.BucketMovementService
-                .GetAllFromBucket(_bucketId, startingMonth, DateTime.MaxValue)
+                .GetAllFromBucket(BucketId, startingMonth, DateTime.MaxValue)
                 .Select(i => new BucketActivity(i))
                 .ToList());
 
@@ -224,11 +224,11 @@ namespace OpenBudgeteer.Core.ViewModels.Helper
                     //TODO Consider rewrite for more optimized query
                     var lastDayOfMonth = month.AddMonths(1).AddDays(-1);
                     var transactions = ServiceManager.BudgetedTransactionService
-                        .GetAllFromBucket(_bucketId, DateTime.MinValue, lastDayOfMonth)
+                        .GetAllFromBucket(BucketId, DateTime.MinValue, lastDayOfMonth)
                         .ToList();
                         
                     var bucketMovements = ServiceManager.BucketMovementService
-                        .GetAllFromBucket(_bucketId, DateTime.MinValue, lastDayOfMonth)
+                        .GetAllFromBucket(BucketId, DateTime.MinValue, lastDayOfMonth)
                         .ToList();
 
                     // Query split required due to incompatibility of decimal Sum operation on sqlite (see issue 57)

--- a/OpenBudgeteer.Core/ViewModels/Helper/TransactionListingViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/Helper/TransactionListingViewModel.cs
@@ -84,10 +84,14 @@ public class TransactionListingViewModel : ViewModelBase
         {
             _transactions.Clear();
 
+            var allAccounts = ServiceManager.AccountService.GetAll()
+                .Select(i => AccountViewModel.CreateFromAccount(ServiceManager, i)).ToList();
+            var allBuckets = ServiceManager.BucketService.GetAllWithSystemBuckets();
+
             // Get all BankTransaction
             var transactionTasks = ServiceManager.BudgetedTransactionService.GetAllFromBucket(bucketId)
                 .Select(i => 
-                    TransactionViewModel.CreateFromTransactionWithoutBucketsAsync(ServiceManager, i.Transaction))
+                    TransactionViewModel.CreateFromTransactionAsync(ServiceManager, allAccounts, allBuckets, i.Transaction))
                 .ToList();
 
             if (withMovements)

--- a/OpenBudgeteer.Core/ViewModels/Helper/TransactionListingViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/Helper/TransactionListingViewModel.cs
@@ -86,7 +86,7 @@ public class TransactionListingViewModel : ViewModelBase
 
             var allAccounts = ServiceManager.AccountService.GetAll()
                 .Select(i => AccountViewModel.CreateFromAccount(ServiceManager, i)).ToList();
-            var allBuckets = ServiceManager.BucketService.GetAllWithSystemBuckets();
+            var allBuckets = ServiceManager.BucketService.GetAll();
 
             // Get all BankTransaction
             var transactionTasks = ServiceManager.BudgetedTransactionService.GetAllFromBucket(bucketId)

--- a/OpenBudgeteer.Core/ViewModels/PageViewModels/DataConsistencyPageViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/PageViewModels/DataConsistencyPageViewModel.cs
@@ -78,7 +78,7 @@ public class DataConsistencyPageViewModel : ViewModelBase
             const string checkName = "Bucket balance";
             var results = new List<Tuple<DataConsistencyCheckResult.StatusCode, string[]>>();
             var checkTasks = ServiceManager.BucketService
-                .GetAll()
+                .GetAllWithoutSystemBuckets()
                 .Select(bucket => Task.Run(() =>
                 {
                     var bucketBalance = ServiceManager.BudgetedTransactionService.GetAllFromBucket(bucket.Id)
@@ -196,7 +196,7 @@ public class DataConsistencyPageViewModel : ViewModelBase
             const string checkName = "Budgeted Transaction outside of validity date";
             var results = new List<Tuple<DataConsistencyCheckResult.StatusCode, string, List<BankTransaction>>>();
             var checkTasks = ServiceManager.BucketService
-                .GetAll()
+                .GetAllWithoutSystemBuckets()
                 .Where(i => i.IsInactive)
                 .Select(bucket => Task.Run(() =>
                 {


### PR DESCRIPTION
fixes #256

For transactions split between multiple buckets, only show the amount assigned to the selected bucket in the bucket detail list.