### PR TITLE
Fix various typos

### DIFF
--- a/OpenBudgeteer.API/ConfigureSwaggerOptions.cs
+++ b/OpenBudgeteer.API/ConfigureSwaggerOptions.cs
@@ -35,7 +35,7 @@ public class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
 
     private static OpenApiInfo CreateInfoForApiVersion( ApiVersionDescription description )
     {
-        var text = new StringBuilder( "Documention of OpenBudgeteer API mainly interacting with the Database." );
+        var text = new StringBuilder( "Documentation of OpenBudgeteer API mainly interacting with the Database." );
         var info = new OpenApiInfo()
         {
             Title = "OpenBudgeteer API",

--- a/OpenBudgeteer.Blazor/Common/InputLargeTextArea/InputLargeTextArea.cs
+++ b/OpenBudgeteer.Blazor/Common/InputLargeTextArea/InputLargeTextArea.cs
@@ -81,7 +81,7 @@ namespace OpenBudgeteer.Blazor.Common.InputLargeTextArea
             => OnChange.InvokeAsync(new InputLargeTextAreaChangeEventArgs(this, length));
 
         /// <summary>
-        /// Retrieves the textarea value asyncronously.
+        /// Retrieves the textarea value asynchronously.
         /// </summary>
         /// <param name="maxLength">The maximum length of content to fetch from the textarea.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> used to relay cancellation of the request.</param>
@@ -112,7 +112,7 @@ namespace OpenBudgeteer.Blazor.Common.InputLargeTextArea
         }
 
         /// <summary>
-        /// Sets the textarea value asyncronously.
+        /// Sets the textarea value asynchronously.
         /// </summary>
         /// <param name="streamWriter">A <see cref="System.IO.StreamWriter"/> used to set the value of the textarea.</param>
         /// <param name="leaveTextAreaEnabled"><see langword="false" /> to disable the textarea while setting new content from the stream, otherwise <see langword="true" /> to allow it to be editable. Defaults to <see langword="false" />.</param>

--- a/OpenBudgeteer.Blazor/Pages/Bucket.razor.cs
+++ b/OpenBudgeteer.Blazor/Pages/Bucket.razor.cs
@@ -186,7 +186,7 @@ public partial class Bucket : ComponentBase
     private void CloseErrorDialog()
     {
         _isErrorModalDialogVisible = false;
-        // In case error occuring in EditBucketDialog, display it again
+        // In case error occurring in EditBucketDialog, display it again
         if (_hasErrorInBucketModalDialog)
         {
             _isEditBucketModalDialogVisible = true;

--- a/OpenBudgeteer.Core/ViewModels/EntityViewModels/MappingRuleViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/EntityViewModels/MappingRuleViewModel.cs
@@ -41,7 +41,7 @@ public class MappingRuleViewModel : BaseEntityViewModel<MappingRule>
 
     private string _comparisonValue;
     /// <summary>
-    /// Value which should be used for the comparision
+    /// Value which should be used for the comparison
     /// </summary>
     public string ComparisonValue 
     { 

--- a/OpenBudgeteer.Core/ViewModels/EntityViewModels/TransactionViewModel.cs
+++ b/OpenBudgeteer.Core/ViewModels/EntityViewModels/TransactionViewModel.cs
@@ -480,7 +480,7 @@ public class TransactionViewModel : BaseEntityViewModel<BankTransaction>
     }
 
     /// <summary>
-    /// Event that handles the deletion of teh requested Bucket
+    /// Event that handles the deletion of the requested Bucket
     /// </summary>
     /// <param name="sender">Object that has triggered the event</param>
     /// <param name="args">Event Arguments about deletion request</param>


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.bundle.min.js" -L cace,cacl,eacf,inout,re-use,totalin,totalout`