### PR TITLE
Fix DateOnly Mysql Migration

### DIFF
--- a/OpenBudgeteer.Core.Data.MySql.Migrations/20250301100128_DateTimeToDateOnly.cs
+++ b/OpenBudgeteer.Core.Data.MySql.Migrations/20250301100128_DateTimeToDateOnly.cs
@@ -42,6 +42,12 @@ namespace OpenBudgeteer.Core.Data.MySql.Migrations
                 nullable: false,
                 oldClrType: typeof(DateTime),
                 oldType: "datetime(6)");
+            
+           migrationBuilder.Sql(@"
+               UPDATE Bucket
+               SET IsInactiveFrom = '9999-12-31'
+               WHERE IsInactiveFrom > '9999-12-31';
+           ");
 
             migrationBuilder.AlterColumn<DateOnly>(
                 name: "ValidFrom",


### PR DESCRIPTION
My DB migration failed with
```
fail: 3/31/2025 20:35:19.689 RelationalEventId.CommandError[20102] (Microsoft.EntityFrameworkCore.Database.Command)
      Failed executing DbCommand (14ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
      ALTER TABLE `Bucket` MODIFY COLUMN `IsInactiveFrom` date NOT NULL;
fail: Microsoft.Extensions.Hosting.Internal.Host[11]
      Hosting failed to start
      MySqlConnector.MySqlException (0x80004005): Datetime function: datetime field overflow

```
I did not test the postgres migration with already existing data, it might also be required.