### PR TITLE
Fix "Unable to focus an invalid element" on InfoDialog

### DIFF
--- a/OpenBudgeteer.Blazor/Shared/Dialog/InfoDialog.razor
+++ b/OpenBudgeteer.Blazor/Shared/Dialog/InfoDialog.razor
@@ -1,4 +1,4 @@
-﻿<MudDialog Class="dialog-background">
+﻿<MudDialog Class="dialog-background" DefaultFocus="DefaultFocus.None">
     <TitleContent>
         <MudText Typo="Typo.h6">@Title</MudText>
     </TitleContent>


### PR DESCRIPTION
The issue in #317 has reappeared for me, especially on mobile (Firefox Android).

Fix: https://github.com/MudBlazor/MudBlazor/issues/8746#issuecomment-2065433064

For me, only the InfoDialog is affected (maybe because there is nothing to focus on?), we could also disable this
globally by setting `MudGlobal.DialogDefaults.DefaultFocus = DefaultFocus.None`