### PR TITLE
 feat: add CSV export feature - AI aided in authorship

### DIFF
--- a/OpenBudgeteer.API/Program.cs
+++ b/OpenBudgeteer.API/Program.cs
@@ -242,6 +242,38 @@ import.MapDelete( "/{id:guid}", (Guid id) => importProfileService.Delete(id));
 
 #endregion
 
+#region Export
+
+// CSV Export endpoints — return file downloads for use in spreadsheet tools or AI analysis pipelines.
+// All date params use ISO 8601 (yyyy-MM-dd). Omit start/end for an unbounded export.
+var export = app.MapGroup("/export").WithTags("export");
+
+// GET /export/transactions?start=2024-01-01&end=2024-12-31[&accountId=guid]
+export.MapGet("/transactions", (DateOnly? start, DateOnly? end, Guid? accountId) =>
+{
+    var bytes = serviceManager.CsvExportService.ExportTransactions(start, end, accountId);
+    var filename = $"transactions_{DateOnly.FromDateTime(DateTime.Today):yyyy-MM-dd}.csv";
+    return Results.File(bytes, "text/csv; charset=utf-8", filename);
+});
+
+// GET /export/buckets[?includeInactive=true]
+export.MapGet("/buckets", (bool? includeInactive) =>
+{
+    var bytes = serviceManager.CsvExportService.ExportBuckets(includeInactive ?? false);
+    var filename = $"buckets_{DateOnly.FromDateTime(DateTime.Today):yyyy-MM-dd}.csv";
+    return Results.File(bytes, "text/csv; charset=utf-8", filename);
+});
+
+// GET /export/movements?start=2024-01-01&end=2024-12-31
+export.MapGet("/movements", (DateOnly? start, DateOnly? end) =>
+{
+    var bytes = serviceManager.CsvExportService.ExportBucketMovements(start, end);
+    var filename = $"bucket_movements_{DateOnly.FromDateTime(DateTime.Today):yyyy-MM-dd}.csv";
+    return Results.File(bytes, "text/csv; charset=utf-8", filename);
+});
+
+#endregion
+
 app.MapOpenApi("/openapi/{documentName}/openapi.json");
 app.MapScalarApiReference("/api", options =>
 {

--- a/OpenBudgeteer.Blazor/Pages/Export.razor
+++ b/OpenBudgeteer.Blazor/Pages/Export.razor
@@ -1,0 +1,146 @@
+@page "/export"
+@attribute [Authorize]
+@using BankAccount = OpenBudgeteer.Core.Data.Entities.Models.Account
+
+<!-- Page Title -->
+<MudText Class="mb-4"
+         Typo="Typo.h5">
+    Export Data
+</MudText>
+<MudText Class="mb-6"
+         Typo="Typo.body1">
+    Download your budget data as CSV files for use in spreadsheets, AI analysis tools, or custom applications.
+</MudText>
+
+<!-- Three export tabs: Transactions / Buckets / Bucket Movements -->
+<MudTabs Elevation="2"
+         Rounded="true"
+         ApplyEffectsToContainer="true">
+
+    <!-- ── Transactions Tab ─────────────────────────────────────────────── -->
+    <MudTabPanel Text="Transactions">
+        <MudCard Class="mt-4">
+            <MudCardContent>
+                <MudText Class="mb-3"
+                         Typo="Typo.body2">
+                    Exports bank transactions with their bucket assignments.
+                    Split transactions produce multiple rows (one per bucket).
+                    Columns: <em>date, payee, memo, amount, type, account, bucket, bucket_group, bucket_amount</em>
+                </MudText>
+                <!-- Filter controls -->
+                <MudGrid>
+                    <MudItem xs="12" sm="4">
+                        <MudDatePicker Label="Start date (optional)"
+                                       Date="@_txStartDateTime"
+                                       DateChanged="@(d => _txStartDateTime = d)"
+                                       Clearable="true"
+                                       ShowToolbar="false"
+                                       Margin="Margin.Dense"/>
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudDatePicker Label="End date (optional)"
+                                       Date="@_txEndDateTime"
+                                       DateChanged="@(d => _txEndDateTime = d)"
+                                       Clearable="true"
+                                       ShowToolbar="false"
+                                       Margin="Margin.Dense"/>
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <!-- Optional account filter: ToStringFunc tells MudBlazor how to render the selected Account entity in the trigger button -->
+                        <MudSelect T="BankAccount?"
+                                   Label="Account (optional — all if blank)"
+                                   @bind-Value="_txAccount"
+                                   ToStringFunc="@(a => a?.Name ?? string.Empty)"
+                                   Clearable="true"
+                                   Margin="Margin.Dense">
+                            @foreach (var account in _accounts)
+                            {
+                                <MudSelectItem T="BankAccount?" Value="@account">@account.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                </MudGrid>
+            </MudCardContent>
+            <MudCardActions>
+                <MudButton OnClick="DownloadTransactions"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Download"
+                           Variant="Variant.Filled">
+                    Download Transactions CSV
+                </MudButton>
+            </MudCardActions>
+        </MudCard>
+    </MudTabPanel>
+
+    <!-- ── Buckets Tab ──────────────────────────────────────────────────── -->
+    <MudTabPanel Text="Buckets">
+        <MudCard Class="mt-4">
+            <MudCardContent>
+                <MudText Class="mb-3"
+                         Typo="Typo.body2">
+                    Exports all user-created buckets with their current configuration.
+                    System buckets (Income, Transfer) are always excluded.
+                    Columns: <em>bucket_id, name, group, bucket_type, target_amount, notes, valid_from, is_active</em>
+                </MudText>
+                <!-- Filter controls -->
+                <MudGrid>
+                    <MudItem xs="12" sm="4"
+                             Class="d-flex align-center">
+                        <MudSwitch @bind-Value="_includeInactive"
+                                   Color="Color.Primary"
+                                   Label="Include inactive buckets"/>
+                    </MudItem>
+                </MudGrid>
+            </MudCardContent>
+            <MudCardActions>
+                <MudButton OnClick="DownloadBuckets"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Download"
+                           Variant="Variant.Filled">
+                    Download Buckets CSV
+                </MudButton>
+            </MudCardActions>
+        </MudCard>
+    </MudTabPanel>
+
+    <!-- ── Bucket Movements Tab ─────────────────────────────────────────── -->
+    <MudTabPanel Text="Bucket Movements">
+        <MudCard Class="mt-4">
+            <MudCardContent>
+                <MudText Class="mb-3"
+                         Typo="Typo.body2">
+                    Exports manual fund movements between buckets.
+                    Columns: <em>movement_id, movement_date, bucket, amount</em>
+                </MudText>
+                <!-- Filter controls -->
+                <MudGrid>
+                    <MudItem xs="12" sm="4">
+                        <MudDatePicker Label="Start date (optional)"
+                                       Date="@_mvStartDateTime"
+                                       DateChanged="@(d => _mvStartDateTime = d)"
+                                       Clearable="true"
+                                       ShowToolbar="false"
+                                       Margin="Margin.Dense"/>
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudDatePicker Label="End date (optional)"
+                                       Date="@_mvEndDateTime"
+                                       DateChanged="@(d => _mvEndDateTime = d)"
+                                       Clearable="true"
+                                       ShowToolbar="false"
+                                       Margin="Margin.Dense"/>
+                    </MudItem>
+                </MudGrid>
+            </MudCardContent>
+            <MudCardActions>
+                <MudButton OnClick="DownloadMovements"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Download"
+                           Variant="Variant.Filled">
+                    Download Bucket Movements CSV
+                </MudButton>
+            </MudCardActions>
+        </MudCard>
+    </MudTabPanel>
+
+</MudTabs>

--- a/OpenBudgeteer.Blazor/Pages/Export.razor.cs
+++ b/OpenBudgeteer.Blazor/Pages/Export.razor.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using OpenBudgeteer.Core.Data.Contracts.Services;
+// Alias required: Account.razor in this namespace compiles to a class also named "Account",
+// which shadows the entity type without this alias.
+using BankAccount = OpenBudgeteer.Core.Data.Entities.Models.Account;
+
+namespace OpenBudgeteer.Blazor.Pages;
+
+/// <summary>
+/// Code-behind for the Export page.
+/// Provides filter state and download triggers for all three CSV export types.
+/// Downloads are initiated by navigating to Minimal API endpoints in Program.cs
+/// with forceLoad:true so the browser makes a real HTTP request and receives the file.
+/// </summary>
+public partial class Export : ComponentBase
+{
+    [Inject] private NavigationManager NavigationManager { get; set; } = null!;
+    [Inject] private IServiceManager ServiceManager { get; set; } = null!;
+
+    // ── Transaction filter state ──────────────────────────────────────────
+    // MudDatePicker works with DateTime? so we convert to DateOnly? at download time.
+    private DateTime? _txStartDateTime;
+    private DateTime? _txEndDateTime;
+    private BankAccount?  _txAccount;
+
+    // ── Bucket filter state ───────────────────────────────────────────────
+    private bool _includeInactive;
+
+    // ── Bucket movement filter state ──────────────────────────────────────
+    private DateTime? _mvStartDateTime;
+    private DateTime? _mvEndDateTime;
+
+    // Account list for the transaction account dropdown
+    private IList<BankAccount> _accounts = new List<BankAccount>();
+
+    protected override Task OnInitializedAsync()
+    {
+        // Load active accounts for the transaction filter dropdown
+        _accounts = ServiceManager.AccountService.GetActiveAccounts().ToList();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Triggers download of the transactions CSV.
+    /// Navigates to the /export/transactions Minimal API endpoint which returns the file.
+    /// </summary>
+    private void DownloadTransactions()
+    {
+        var url = BuildUrl("/export/transactions",
+            ("start",     _txStartDateTime.HasValue ? DateOnly.FromDateTime(_txStartDateTime.Value).ToString("yyyy-MM-dd") : null),
+            ("end",       _txEndDateTime.HasValue   ? DateOnly.FromDateTime(_txEndDateTime.Value).ToString("yyyy-MM-dd")   : null),
+            ("accountId", _txAccount?.Id.ToString()));
+
+        // forceLoad bypasses Blazor routing so the browser makes a real HTTP GET
+        // and the server responds with Content-Disposition:attachment (file download).
+        NavigationManager.NavigateTo(url, forceLoad: true);
+    }
+
+    /// <summary>
+    /// Triggers download of the buckets CSV.
+    /// </summary>
+    private void DownloadBuckets()
+    {
+        var url = BuildUrl("/export/buckets",
+            ("includeInactive", _includeInactive ? "true" : null));
+
+        NavigationManager.NavigateTo(url, forceLoad: true);
+    }
+
+    /// <summary>
+    /// Triggers download of the bucket movements CSV.
+    /// </summary>
+    private void DownloadMovements()
+    {
+        var url = BuildUrl("/export/movements",
+            ("start", _mvStartDateTime.HasValue ? DateOnly.FromDateTime(_mvStartDateTime.Value).ToString("yyyy-MM-dd") : null),
+            ("end",   _mvEndDateTime.HasValue   ? DateOnly.FromDateTime(_mvEndDateTime.Value).ToString("yyyy-MM-dd")   : null));
+
+        NavigationManager.NavigateTo(url, forceLoad: true);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a URL from a base path and optional query parameters.
+    /// Null-valued params are omitted so the endpoint receives clean input.
+    /// </summary>
+    private static string BuildUrl(string basePath, params (string Key, string? Value)[] queryParams)
+    {
+        var nonNull = queryParams.Where(p => p.Value is not null).ToList();
+        if (!nonNull.Any()) return basePath;
+
+        var sb = new StringBuilder(basePath).Append('?');
+        sb.Append(string.Join("&", nonNull.Select(p =>
+            $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value!)}")));
+        return sb.ToString();
+    }
+}

--- a/OpenBudgeteer.Blazor/Program.cs
+++ b/OpenBudgeteer.Blazor/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using DotNetEnv;
 using DotNetEnv.Configuration;
@@ -18,6 +19,7 @@ using OpenBudgeteer.Core.Data.Entities;
 using OpenBudgeteer.Core.Data.Initialization;
 using OpenBudgeteer.Core.Data.Services.EFCore;
 using OpenBudgeteer.Core.ViewModels.Helper;
+using Microsoft.AspNetCore.Http;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = new ConfigurationBuilder()
@@ -80,6 +82,42 @@ if (authEnabled)
 {
     app.MapAuthenticationEndpoints();
 }
+
+// CSV Export endpoints — these are standard Minimal API GET routes that return file downloads.
+// The Blazor UI triggers them via NavigationManager.NavigateTo(url, forceLoad: true).
+// forceLoad bypasses Blazor client-side routing so the browser makes a real HTTP request;
+// the browser sees Content-Disposition: attachment and downloads without navigating away.
+var exportGroup = app.MapGroup("/export");
+
+exportGroup.MapGet("/transactions", (
+    IServiceManager svc,
+    DateOnly? start,
+    DateOnly? end,
+    Guid? accountId) =>
+{
+    var bytes = svc.CsvExportService.ExportTransactions(start, end, accountId);
+    var filename = $"transactions_{DateOnly.FromDateTime(DateTime.Today):yyyy-MM-dd}.csv";
+    return Results.File(bytes, "text/csv; charset=utf-8", filename);
+});
+
+exportGroup.MapGet("/buckets", (
+    IServiceManager svc,
+    bool? includeInactive) =>
+{
+    var bytes = svc.CsvExportService.ExportBuckets(includeInactive ?? false);
+    var filename = $"buckets_{DateOnly.FromDateTime(DateTime.Today):yyyy-MM-dd}.csv";
+    return Results.File(bytes, "text/csv; charset=utf-8", filename);
+});
+
+exportGroup.MapGet("/movements", (
+    IServiceManager svc,
+    DateOnly? start,
+    DateOnly? end) =>
+{
+    var bytes = svc.CsvExportService.ExportBucketMovements(start, end);
+    var filename = $"bucket_movements_{DateOnly.FromDateTime(DateTime.Today):yyyy-MM-dd}.csv";
+    return Results.File(bytes, "text/csv; charset=utf-8", filename);
+});
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/OpenBudgeteer.Blazor/Shared/NavMenu.razor
+++ b/OpenBudgeteer.Blazor/Shared/NavMenu.razor
@@ -17,6 +17,9 @@
     <MudNavLink Href="report"
                 Match="NavLinkMatch.Prefix">Report
     </MudNavLink>
+    <MudNavLink Href="export"
+                Match="NavLinkMatch.Prefix">Export
+    </MudNavLink>
     <MudNavLink Href="rules"
                 Match="NavLinkMatch.Prefix">Rules
     </MudNavLink>

--- a/OpenBudgeteer.Core.Data.Contracts/Services/ICsvExportService.cs
+++ b/OpenBudgeteer.Core.Data.Contracts/Services/ICsvExportService.cs
@@ -1,0 +1,34 @@
+namespace OpenBudgeteer.Core.Data.Contracts.Services;
+
+/// <summary>
+/// Provides methods for exporting budget data to CSV format.
+/// All methods return UTF-8 encoded byte arrays suitable for direct file download.
+/// </summary>
+public interface ICsvExportService
+{
+    /// <summary>
+    /// Exports bank transactions as CSV. Split transactions produce multiple rows (one per bucket assignment).
+    /// Unassigned transactions produce one row with empty bucket columns.
+    /// </summary>
+    /// <param name="startDate">Inclusive start date filter. Null means no lower bound.</param>
+    /// <param name="endDate">Inclusive end date filter. Null means no upper bound.</param>
+    /// <param name="accountId">Optional account filter. Null exports all accounts.</param>
+    /// <returns>UTF-8 CSV bytes with columns: date, payee, memo, amount, type, account, bucket, bucket_group, bucket_amount</returns>
+    byte[] ExportTransactions(DateOnly? startDate, DateOnly? endDate, Guid? accountId = null);
+
+    /// <summary>
+    /// Exports all buckets (excluding internal system buckets) as CSV.
+    /// Uses the most recent BucketVersion for type and target information.
+    /// </summary>
+    /// <param name="includeInactive">When false (default), only active buckets are exported.</param>
+    /// <returns>UTF-8 CSV bytes with columns: bucket_id, name, group, bucket_type, target_amount, notes, valid_from, is_active</returns>
+    byte[] ExportBuckets(bool includeInactive = false);
+
+    /// <summary>
+    /// Exports bucket movements (manual fund transfers between buckets) as CSV.
+    /// </summary>
+    /// <param name="startDate">Inclusive start date filter. Null means no lower bound.</param>
+    /// <param name="endDate">Inclusive end date filter. Null means no upper bound.</param>
+    /// <returns>UTF-8 CSV bytes with columns: movement_id, movement_date, bucket, amount</returns>
+    byte[] ExportBucketMovements(DateOnly? startDate, DateOnly? endDate);
+}

--- a/OpenBudgeteer.Core.Data.Contracts/Services/IServiceManager.cs
+++ b/OpenBudgeteer.Core.Data.Contracts/Services/IServiceManager.cs
@@ -13,6 +13,8 @@ public interface IServiceManager
     IBudgetedTransactionService BudgetedTransactionService { get; }
     IImportProfileService ImportProfileService { get; }
     IRecurringBankTransactionService RecurringBankTransactionService { get; }
+    /// <summary>Provides CSV export for transactions, buckets, and bucket movements.</summary>
+    ICsvExportService CsvExportService { get; }
 
     public ILogger CreateLogger(Type type);
 }

--- a/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreCsvExportService.cs
+++ b/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreCsvExportService.cs
@@ -1,0 +1,239 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using OpenBudgeteer.Core.Data.Contracts.Services;
+using OpenBudgeteer.Core.Data.Entities;
+
+namespace OpenBudgeteer.Core.Data.Services.EFCore;
+
+/// <summary>
+/// Exports budget data to RFC 4180-compliant CSV bytes.
+/// Unlike other services this class does NOT extend EFCoreBaseService because export
+/// is a read-only cross-entity concern that benefits from custom EF Core Include chains
+/// rather than going through the single-entity repository layer.
+/// </summary>
+public class EFCoreCsvExportService : ICsvExportService
+{
+    // Internal system bucket IDs that should never appear in user-facing exports.
+    // 000001 = "Income" system bucket, 000002 = "Transfer" system bucket.
+    private static readonly Guid SystemBucketIncomeId  = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid SystemBucketTransferId = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+    private readonly IDbContextFactory<DatabaseContext> _dbContextFactory;
+    private readonly ILogger<EFCoreCsvExportService> _logger;
+
+    public EFCoreCsvExportService(
+        IDbContextFactory<DatabaseContext> dbContextFactory,
+        ILogger<EFCoreCsvExportService> logger)
+    {
+        _dbContextFactory = dbContextFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Exports bank transactions. Each BudgetedTransaction (bucket assignment) becomes its own
+    /// CSV row so that split transactions are fully visible to analysis tools.
+    /// Transactions with no bucket assignment produce one row with empty bucket columns.
+    /// </summary>
+    public byte[] ExportTransactions(DateOnly? startDate, DateOnly? endDate, Guid? accountId = null)
+    {
+        try
+        {
+            using var dbContext = _dbContextFactory.CreateDbContext();
+
+            // Custom include chain: AllWithIncludedEntities() only includes Account, not
+            // BudgetedTransactions or their Buckets, so we query the context directly here.
+            var query = dbContext.BankTransaction
+                .Include(t => t.Account)
+                .Include(t => t.BudgetedTransactions)
+                    .ThenInclude(bt => bt.Bucket)
+                        .ThenInclude(b => b!.BucketGroup)
+                .AsNoTracking()
+                .Where(t =>
+                    t.TransactionDate >= (startDate ?? DateOnly.MinValue) &&
+                    t.TransactionDate <= (endDate   ?? DateOnly.MaxValue));
+
+            if (accountId.HasValue)
+                query = query.Where(t => t.AccountId == accountId.Value);
+
+            var transactions = query.OrderBy(t => t.TransactionDate).ToList();
+
+            var headers = new[] { "date", "payee", "memo", "amount", "type", "account", "bucket", "bucket_group", "bucket_amount" };
+            var rows = new List<string[]>();
+
+            foreach (var tx in transactions)
+            {
+                var date    = tx.TransactionDate.ToString("yyyy-MM-dd");
+                var payee   = tx.Payee ?? string.Empty;
+                var memo    = tx.Memo  ?? string.Empty;
+                var amount  = tx.Amount.ToString("G", CultureInfo.InvariantCulture);
+                var type    = tx.Amount >= 0 ? "credit" : "debit";
+                var account = tx.Account?.Name ?? string.Empty;
+
+                if (tx.BudgetedTransactions == null || !tx.BudgetedTransactions.Any())
+                {
+                    // Unassigned transaction — one row with empty bucket columns
+                    rows.Add(new[] { date, payee, memo, amount, type, account, "", "", "" });
+                }
+                else
+                {
+                    // Split transaction — one row per bucket assignment
+                    foreach (var bt in tx.BudgetedTransactions)
+                    {
+                        var bucketName  = bt.Bucket?.Name          ?? string.Empty;
+                        var bucketGroup = bt.Bucket?.BucketGroup?.Name ?? string.Empty;
+                        var bucketAmt   = bt.Amount.ToString("G", CultureInfo.InvariantCulture);
+                        rows.Add(new[] { date, payee, memo, amount, type, account, bucketName, bucketGroup, bucketAmt });
+                    }
+                }
+            }
+
+            return BuildCsvBytes(rows, headers);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error exporting transactions to CSV.");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Exports all user-created buckets. System buckets (Income, Transfer) are always excluded.
+    /// Uses the most-recent BucketVersion for type and target amount information.
+    /// </summary>
+    public byte[] ExportBuckets(bool includeInactive = false)
+    {
+        try
+        {
+            using var dbContext = _dbContextFactory.CreateDbContext();
+
+            var query = dbContext.Bucket
+                .Include(b => b.BucketGroup)
+                .Include(b => b.BucketVersions)
+                .AsNoTracking()
+                .Where(b =>
+                    b.Id != SystemBucketIncomeId &&
+                    b.Id != SystemBucketTransferId);
+
+            if (!includeInactive)
+                query = query.Where(b => !b.IsInactive);
+
+            var buckets = query.OrderBy(b => b.BucketGroup!.Position).ThenBy(b => b.Name).ToList();
+
+            var headers = new[] { "bucket_id", "name", "group", "bucket_type", "target_amount", "notes", "valid_from", "is_active" };
+            var rows = new List<string[]>();
+
+            foreach (var bucket in buckets)
+            {
+                // Select the most recent version as the "current" configuration
+                var version = bucket.BucketVersions?
+                    .OrderByDescending(v => v.ValidFrom)
+                    .FirstOrDefault();
+
+                rows.Add(new[]
+                {
+                    bucket.Id.ToString(),
+                    bucket.Name          ?? string.Empty,
+                    bucket.BucketGroup?.Name ?? string.Empty,
+                    version != null ? BucketTypeToString(version.BucketType) : string.Empty,
+                    version?.BucketTypeYParam.ToString("G", CultureInfo.InvariantCulture) ?? "0",
+                    version?.Notes       ?? string.Empty,
+                    bucket.ValidFrom.ToString("yyyy-MM-dd"),
+                    (!bucket.IsInactive).ToString().ToLowerInvariant()
+                });
+            }
+
+            return BuildCsvBytes(rows, headers);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error exporting buckets to CSV.");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Exports bucket movements (manual fund transfers between buckets) ordered by date.
+    /// </summary>
+    public byte[] ExportBucketMovements(DateOnly? startDate, DateOnly? endDate)
+    {
+        try
+        {
+            using var dbContext = _dbContextFactory.CreateDbContext();
+
+            var movements = dbContext.BucketMovement
+                .Include(m => m.Bucket)
+                .AsNoTracking()
+                .Where(m =>
+                    m.MovementDate >= (startDate ?? DateOnly.MinValue) &&
+                    m.MovementDate <= (endDate   ?? DateOnly.MaxValue))
+                .OrderBy(m => m.MovementDate)
+                .ToList();
+
+            var headers = new[] { "movement_id", "movement_date", "bucket", "amount" };
+            var rows = movements.Select(m => new[]
+            {
+                m.Id.ToString(),
+                m.MovementDate.ToString("yyyy-MM-dd"),
+                m.Bucket?.Name ?? string.Empty,
+                m.Amount.ToString("G", CultureInfo.InvariantCulture)
+            }).ToList();
+
+            return BuildCsvBytes(rows, headers);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error exporting bucket movements to CSV.");
+            throw;
+        }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    // UTF-8 encoding with BOM (0xEF 0xBB 0xBF) so Excel opens the file correctly
+    // without showing garbled characters for non-ASCII payee or bucket names.
+    private static readonly UTF8Encoding Utf8WithBom = new(encoderShouldEmitUTF8Identifier: true);
+
+    /// <summary>
+    /// Builds a UTF-8 CSV byte array (with BOM for Excel compatibility) from a header row and data rows.
+    /// </summary>
+    private static byte[] BuildCsvBytes(IEnumerable<string[]> rows, string[] headers)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine(string.Join(",", headers.Select(CsvEscape)));
+        foreach (var row in rows)
+            sb.AppendLine(string.Join(",", row.Select(CsvEscape)));
+
+        return Utf8WithBom.GetBytes(sb.ToString());
+    }
+
+    /// <summary>
+    /// Wraps a CSV field in double-quotes if it contains a comma, double-quote, or newline.
+    /// Inner double-quotes are escaped by doubling them (RFC 4180 §2.7).
+    /// </summary>
+    private static string CsvEscape(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        // Only quote when necessary to keep output clean
+        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+
+        return value;
+    }
+
+    /// <summary>
+    /// Converts the numeric BucketType identifier to a human-readable label.
+    /// Type codes are defined by OpenBudgeteer convention (not an enum in the data layer).
+    /// </summary>
+    private static string BucketTypeToString(int bucketType) => bucketType switch
+    {
+        1 => "Standard",
+        2 => "Monthly Expense",
+        3 => "Expense Every X Months",
+        4 => "Monthly Income",
+        _ => $"Unknown ({bucketType})"
+    };
+}

--- a/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreServiceManager.cs
+++ b/OpenBudgeteer.Core.Data.Services/EFCore/EFCoreServiceManager.cs
@@ -31,8 +31,12 @@ public class EFCoreServiceManager : IServiceManager
     public IImportProfileService ImportProfileService => 
         new EFCoreImportProfileService(_dbContextFactory, new Logger<EFCoreImportProfileService>(_loggerFactory));
     
-    public IRecurringBankTransactionService RecurringBankTransactionService => 
+    public IRecurringBankTransactionService RecurringBankTransactionService =>
         new EFCoreRecurringBankTransactionService(_dbContextFactory, new Logger<EFCoreRecurringBankTransactionService>(_loggerFactory));
+
+    /// <summary>Creates a new export service instance backed by the shared DB context factory.</summary>
+    public ICsvExportService CsvExportService =>
+        new EFCoreCsvExportService(_dbContextFactory, new Logger<EFCoreCsvExportService>(_loggerFactory));
 
     private readonly IDbContextFactory<DatabaseContext> _dbContextFactory;
     private readonly ILoggerFactory _loggerFactory;


### PR DESCRIPTION
Closes #351 

Adds the ability to export budget data as CSV files for use in spreadsheets, AI analysis tools, and custom applications.

Three export types:
- Transactions with bucket assignments resolved (split transactions produce one row per bucket)
- Buckets with type, target amount, group, and active status
- Bucket movements (manual fund transfers between buckets)

All exports include date/account filters, UTF-8 BOM for Excel compatibility, and invariant-culture decimal formatting.

New files:
- ICsvExportService — service contract
- EFCoreCsvExportService — implementation using direct EF Core queries (custom include chain: BankTransaction → Account/BudgetedTransactions → Bucket → BucketGroup, not available via existing repositories)
- Export.razor / Export.razor.cs — Blazor page with MudTabs UI

Modified files:
- IServiceManager / EFCoreServiceManager — wire up the new service
- Blazor/Program.cs + API/Program.cs — expose /export/transactions, /export/buckets, /export/movements as Minimal API GET endpoints
- NavMenu.razor — add Export link in sidebar